### PR TITLE
Remove manage to stop getting deprecation warnings

### DIFF
--- a/lib/capybara/chromedriver/logger/collector.rb
+++ b/lib/capybara/chromedriver/logger/collector.rb
@@ -53,7 +53,6 @@ module Capybara
           Capybara
             .current_session
             .driver.browser
-            .manage
             .logs
             .get(type)
         end


### PR DESCRIPTION
Based on https://github.com/dbalatero/capybara-chromedriver-logger/pull/38

Seems like if we want this to go away, our best option is to fork and do it ourselves!

Should stop us from getting `WARN Selenium [DEPRECATION] Manager#logs is deprecated. Use Chrome::Driver#logs instead.` when running tests.